### PR TITLE
Script for converting data from plink to dosage format now works correctly. 

### DIFF
--- a/Software/HOWTO.md
+++ b/Software/HOWTO.md
@@ -97,6 +97,15 @@ cd data/dosages
 aws s3 cp s3://imlab-open/Data/1000Genomes/Transcriptome/GEUVADIS/dosagefiles-hapmap2/ . --recursive
 ```
 
+#### Converting from other file formats to the dosage file format
+
+The script [convert_plink_to_dosage.py](convert_plink_to_dosage.py) will convert data in the [binary PED format](http://pngu.mgh.harvard.edu/~purcell/plink/data.shtml#bed) used by the popular [plink](http://pngu.mgh.harvard.edu/~purcell/plink/) program to the dosage file format.
+
+To use [convert_plink_to_dosage.py](convert_plink_to_dosage.py) you will need to have the latest version of plink installed: [plink 1.90 beta](https://www.cog-genomics.org/plink2/). By default, the script expects this available as `plink2`, but the path to the binary can be specified at runtime. 
+
+If your data is in another format, you can use plink to convert your file into the plink binary PED format first.
+Plink can be used to convert data in the [oxford format](https://www.cog-genomics.org/plink2/input#oxford) output by the imputation program [IMPUTE2](https://mathgen.stats.ox.ac.uk/impute/impute_v2.html), data in the [23andMe format](https://www.cog-genomics.org/plink2/input#23file), and [VCF or BCF files](https://www.cog-genomics.org/plink2/input#vcf). The [older version of plink (1.70)](http://pngu.mgh.harvard.edu/~purcell/plink/) can be used to convert data in the [dosage format](http://pngu.mgh.harvard.edu/~purcell/plink/dosage.shtml#format) output by the imputation programs [BEAGLE](http://faculty.washington.edu/browning/beagle/beagle.html) and [MACH](www.sph.umich.edu/csg/abecasis/mach/).
+
 ### Phenotype and Filter Files
 
 The phenotype file is expected to be formatted with the following columns:

--- a/Software/convert_plink_to_dosage.py
+++ b/Software/convert_plink_to_dosage.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
 
   # First we get the minor allele dosages for *all* chromosomes:
   subprocess.call([
-    'plink2', '--bfile', args.bfile, '--geno', '0',
+    'plink2', '--bfile', args.bfile,
     '--recode', 'A-transpose', '--out', args.out
   ])
 
@@ -65,14 +65,14 @@ if __name__ == "__main__":
             fcols = ffile.readline().split()
           else:
             break
-        # Combine columns as per 'dosage' format
-        nline = fcols[0:2] + [bcols[3]]+ fcols[2:5] + dcols[6:]
+        # Combine columns as per 'dosage' format. Impute missing data as 2*MAF.
+        nline = fcols[0:2] + [bcols[3]]+ fcols[2:5] + [fcols[4]*2 if e == "NA" else e for e in dcols[6:]]
         # Write out to the appropriate file for that chromosome
         if fcols[0] != curCHR:
           if curCHR != -1:
             ofile.close()
           ofile = open(args.out + fcols[0] + ".txt", "a")
-          ofile.write(" ".join(nline) + "\n")
+        ofile.write(" ".join(nline) + "\n")
   ofile.close()
 
   # now we need to gzip the files

--- a/Software/convert_plink_to_dosage.py
+++ b/Software/convert_plink_to_dosage.py
@@ -33,13 +33,13 @@ if __name__ == "__main__":
 
   # First we get the minor allele dosages for *all* chromosomes:
   subprocess.call([
-    args[["plink"]], '--bfile', args.bfile,
+    args.plink, '--bfile', args.bfile,
     '--recode', 'A-transpose', '--out', args.out
   ])
 
   # Now calculate the minor allele frequency:
   subprocess.call([
-    args[["plink"]], '--bfile', args.bfile, '--freq', '--out', args.out
+    args.plink, '--bfile', args.bfile, '--freq', '--out', args.out
   ])
 
   # Thanks to Adam Whiteside (https://github.com/adamcw) for

--- a/Software/convert_plink_to_dosage.py
+++ b/Software/convert_plink_to_dosage.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 import gzip
 from argparse import ArgumentParser
+from collections import defaultdict
+from itertools import izip
 
 if __name__ == "__main__":
   parser = ArgumentParser(
@@ -36,59 +38,40 @@ if __name__ == "__main__":
     'plink2', '--bfile', args.bfile, '--freq', '--out', args.out
   ])
 
-  # now we need to process the files line by line to create the dosage files
-  with open(args.out + ".traw") as dfile, open(args.out + ".frq") as ffile, open(args.bfile + ".bim") as bfile:
-    i = 1
-    curCHR = -1
-    while True:
-      # skip the headers
-      if i == 1:
-        dfile.readline()
-        ffile.readline()
-        i += 1
-      else:
-        # First check that we're not at the end of the files
-        dline = dfile.readline()
-        fline = ffile.readline()
-        bline = bfile.readline()
-        if not dline: break
-        if not fline: break
-        if not bline: break
-        # Split into columns by whitespace
-        dcols = dline.split()
-        fcols = fline.split()
-        bcols = bline.split()
-        # Make sure rsIDs match in maf frequency file -- note this cannot
-        # be filtered unlike the --recode 'd file
-        while True:
-          if fcols[1] != dcols[1]:
-            fcols = ffile.readline().split()
-          else:
-            break
-        # Combine columns as per 'dosage' format. Impute missing data as 2*MAF.
-        nline = fcols[0:2] + [bcols[3]]+ fcols[2:5] + [fcols[4]*2 if e == "NA" else e for e in dcols[6:]]
-        # Write out to the appropriate file for that chromosome
-        if fcols[0] != curCHR:
-          if curCHR != -1:
-            ofile.close()
-          ofile = open(args.out + fcols[0] + ".txt", "a")
-        ofile.write(" ".join(nline) + "\n")
-  ofile.close()
+  # Thanks to Adam Whiteside (https://github.com/adamcw) for
+  # cleaning up this code to be more efficient
+  diter = iter(x.split() for x in open(args.out + ".traw"))
+  fiter = iter(x.split() for x in open(args.out + ".frq"))
+  biter = iter(x.split() for x in open(args.bfile + ".bim"))
 
-  # now we need to gzip the files
-  out_dir = os.path.dirname(args.out)
-  prefix = os.path.basename(args.out)
-  for chrfile in [x for x in os.listdir(out_dir) if (x.startswith(prefix) and x.endswith(".txt"))]:
-    f = open(os.path.join(out_dir, chrfile), 'rb')
-    ofile = gzip.open(os.path.join(out_dir, chrfile + ".gz"), "wb")
-    ofile.writelines(f)
-    f.close()
-    ofile.close()
-    # remove non-zipped file
-    os.remove(os.path.join(out_dir, chrfile))
+  buff = defaultdict(list)
+
+  # First skip the header row
+  diter.next()
+  fiter.next()
+
+  # Then process the lines
+  for (dcols, fcols, bcols) in izip(diter, fiter, biter):
+    # Combine columns as per 'dosage' format.
+    # First we add the information columns for each rsID
+    nline = fcols[0:2] + [bcols[3]] + [fcols[3]] + [fcols[2]] + [fcols[4]]
+
+    # Next add the (additive linear) dosage data for the samples.
+    # Impute missing data as 2*MAF.
+    MAF = float(fcols[4])
+    nline = nline + [str(MAF*2) if e == "NA" else e for e in dcols[6:]]
+
+    # Add line to write buffer
+    buff[fcols[0]].append(" ".join(nline) + "\n")
+
+
+  # Write out the buffer
+  for curCHR, lines in buff.iteritems():
+    with gzip.open(args.out + curCHR + ".txt.gz", "wb") as ofile:
+      ofile.writelines(lines)
 
   # Remove left over files
-  os.remove(os.path.join(out_dir, prefix + ".frq"))
-  os.remove(os.path.join(out_dir, prefix + ".traw"))
-  os.remove(os.path.join(out_dir, prefix + ".log"))
+  os.remove(args.out + ".frq")
+  os.remove(args.out + ".traw")
+  os.remove(args.out + ".log")
 

--- a/Software/convert_plink_to_dosage.py
+++ b/Software/convert_plink_to_dosage.py
@@ -20,8 +20,12 @@ if __name__ == "__main__":
     "-o", "--out", dest="out", required=False,
     help="prefix for output files", default="chr"
   )
+  parser.add_argument(
+    "-p", "--plink-binary", dest="plink", default="plink2",
+    help="path to plink (1.9) binary"
+  )
 
-  if len(sys.argv) == 1:
+  if len(sys.argv) == 2:
     parser.print_help()
     sys.exit()
 
@@ -29,13 +33,13 @@ if __name__ == "__main__":
 
   # First we get the minor allele dosages for *all* chromosomes:
   subprocess.call([
-    'plink2', '--bfile', args.bfile,
+    args[["plink"]], '--bfile', args.bfile,
     '--recode', 'A-transpose', '--out', args.out
   ])
 
   # Now calculate the minor allele frequency:
   subprocess.call([
-    'plink2', '--bfile', args.bfile, '--freq', '--out', args.out
+    args[["plink"]], '--bfile', args.bfile, '--freq', '--out', args.out
   ])
 
   # Thanks to Adam Whiteside (https://github.com/adamcw) for


### PR DESCRIPTION
Imputes missing data (SNPs with missing data for some, but not all samples) to 2 \* the minor allele frequency of that SNP as per discussion in pull request #11 
