### PR TITLE
optimizing PrediXcan

### DIFF
--- a/Software/PrediXcan.py
+++ b/Software/PrediXcan.py
@@ -42,7 +42,7 @@ def get_all_dosages(dosage_dir, dosage_prefix, dbuffer=None):
             arr = line.strip().split()
             rsid = arr[1]
             refallele = arr[4]
-            dosage_row = np.array(map(float, arr[6:]))
+            dosage_row = np.array(arr[6:], dtype=np.float64)
             yield rsid, refallele, dosage_row
 
 


### PR DESCRIPTION
In running the working example this made the run go from about 211 seconds to 160.
