### PR TITLE
fix strand issues for non-ambiguous SNPs

### DIFF
--- a/Software/PrediXcan.py
+++ b/Software/PrediXcan.py
@@ -86,6 +86,7 @@ class TranscriptionMatrix:
         self.beta_file = beta_file
         self.gene_file = gene_file
         self.sample_file = sample_file
+        self.complements = {"A":"T","C":"G","G":"C","T":"A"}
 
     def get_gene_list(self):
         if self.gene_file:
@@ -99,7 +100,7 @@ class TranscriptionMatrix:
             self.gene_index = { gene:k for (k, gene) in enumerate(self.gene_list) }
             self.D = np.zeros((len(self.gene_list), len(dosage_row))) # Genes x Cases
         if gene in self.gene_index: #assumes strands are aligned to PrediXcan reference and dosage coding 0 to 2           
-            if ref_allele == allele: 
+            if ref_allele == allele or self.complements[ref_allele] == allele: # assumes non-ambiguous SNPs to resolve strand issues: 
                 self.D[self.gene_index[gene],] += dosage_row * weight
             else:
                 self.D[self.gene_index[gene],] += (2-dosage_row) * weight # Update all cases for that gene 


### PR DESCRIPTION
For the non-ambigous SNPs as provided in PredictDB weights files (A/C, A/G, T/C, T/G) the proposed change eliminates the requirement to flip strands in case the complementary allele is coded in the dosage files.
